### PR TITLE
Support new branches with multiple commits

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: "actions/checkout@master"
       - name: "TODO to Issue"
-        uses: "alstr/todo-to-issue-action@master"
+        uses: ./
         id: "todo"
         with:
           PROJECTS_SECRET: ${{ secrets.PROJECTS_SECRET }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: "actions/checkout@master"
       - name: "TODO to Issue"
-        uses: ./
+        uses: "alstr/todo-to-issue-action@master"
         id: "todo"
         with:
           PROJECTS_SECRET: ${{ secrets.PROJECTS_SECRET }}

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "The path to the repository where the action will be used, e.g. 'alstr/my-repo' (automatically set)"
     required: true
     default: "${{ github.repository }}"
+  BEFORE:
+    description: "The SHA of the last pushed commit (automatically set)"
+    required: true
+    default: "${{ github.event.before }}"        
   SHA:
     description: "The SHA of the latest commit (automatically set)"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,11 @@ inputs:
   BEFORE:
     description: "The SHA of the last pushed commit (automatically set)"
     required: true
-    default: "${{ github.event.before }}"        
+    default: "${{ github.event.before }}"     
+  COMMITS:
+    description: "An array of commit objects describing the pushed commits"
+    required: true
+    default: "${{ github.event.commits }}"            
   SHA:
     description: "The SHA of the latest commit (automatically set)"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   COMMITS:
     description: "An array of commit objects describing the pushed commits"
     required: true
-    default: "${{ github.event.commits }}"            
+    default: "${{ toJSON(github.event.commits) }}"
   SHA:
     description: "The SHA of the latest commit (automatically set)"
     required: true

--- a/main.py
+++ b/main.py
@@ -82,6 +82,7 @@ class GitHubClient(object):
             return diff_request.text
         raise Exception('Could not retrieve diff. Operation will abort.')
 
+# TODO 1
     def _get_existing_issues(self, page=1):
         """Populate the existing issues list."""
         params = {

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ class GitHubClient(object):
         # Retrieve the existing repo issues now so we can easily check them later.
         self._get_existing_issues()
 
-    def get_timestamp(commit):
+    def get_timestamp(self, commit):
         return commit.get('timestamp')
 
     def get_last_diff(self):

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import itertools
 import operator
 
 #TODO First todo
+#TODO Second todo
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import operator
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
+#TODO First TODO
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from enum import Enum
 import itertools
 import operator
 
+#TODO First todo
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0

--- a/main.py
+++ b/main.py
@@ -628,3 +628,4 @@ if __name__ == "__main__":
                 print('Issue could not be closed')
         # Stagger the requests to be on the safe side.
         sleep(1)
+#TODO third todo

--- a/main.py
+++ b/main.py
@@ -13,11 +13,13 @@ from enum import Enum
 import itertools
 import operator
 
+
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0
     DELETED = 1
     UNCHANGED = 2
+
 
 class Issue(object):
     """Basic Issue model for collecting the necessary info to send to GitHub."""

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ class GitHubClient(object):
         self.repo = os.getenv('INPUT_REPO')
         self.before = os.getenv('INPUT_BEFORE')
         self.sha = os.getenv('INPUT_SHA')
+        self.commits = os.getenv('INPUT_COMMITS')
         self.token = os.getenv('INPUT_TOKEN')
         self.issues_url = f'{self.repos_url}{self.repo}/issues'
         self.issue_headers = {
@@ -68,6 +69,7 @@ class GitHubClient(object):
         }
         print(f'Diff url {diff_url}')
         print(f'Before sha {self.before}')
+        print(f'Commits {self.commits}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text

--- a/main.py
+++ b/main.py
@@ -281,7 +281,6 @@ class GitHubClient(object):
             else:
                 print('Issue card could not be added to project')
 
-# TODO 4
 class TodoParser(object):
     """Parser for extracting information from a given diff file."""
     FILE_HUNK_PATTERN = r'(?<=diff)(.*?)(?=diff\s--git\s)'

--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ class Issue(object):
         self.markdown_language = markdown_language
         self.status = status
 
+#TODO Second TODO
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ class Issue(object):
         self.markdown_language = markdown_language
         self.status = status
 
+
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []

--- a/main.py
+++ b/main.py
@@ -12,8 +12,9 @@ import hashlib
 from enum import Enum
 import itertools
 import operator
+import logging
+logging.basicConfig(level=logging.DEBUG)
 
-#TODO First todo
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0
@@ -38,7 +39,6 @@ class Issue(object):
         self.markdown_language = markdown_language
         self.status = status
 
-#TODO Second todo
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []
@@ -628,4 +628,4 @@ if __name__ == "__main__":
                 print('Issue could not be closed')
         # Stagger the requests to be on the safe side.
         sleep(1)
-#TODO third todo
+        

--- a/main.py
+++ b/main.py
@@ -12,8 +12,6 @@ import hashlib
 from enum import Enum
 import itertools
 import operator
-import logging
-logging.basicConfig(level=logging.DEBUG)
 
 #TODO First TODO
 class LineStatus(Enum):
@@ -68,7 +66,6 @@ class GitHubClient(object):
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'
         }
-        logging.debug('URL %', diff_url)
         print(f'Diff url {diff_url}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:

--- a/main.py
+++ b/main.py
@@ -13,14 +13,12 @@ from enum import Enum
 import itertools
 import operator
 
-# TODO comment
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0
     DELETED = 1
     UNCHANGED = 2
 
-# Another comment
 class Issue(object):
     """Basic Issue model for collecting the necessary info to send to GitHub."""
 

--- a/main.py
+++ b/main.py
@@ -78,7 +78,9 @@ class GitHubClient(object):
             diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
         else: 
             # There are several commits: compare with the oldest one
-            oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]['id']
+            print("Case 3")
+            print(f'Case 3 commits {self.commits}')
+            oldest = sorted(self.commits, key=self.get_timestamp)[0]['id']
             diff_url = f'{self.repos_url}{self.repo}/compare/{oldest}...{self.sha}'    
         
         diff_headers = {
@@ -86,7 +88,6 @@ class GitHubClient(object):
             'Authorization': f'token {self.token}'
         }
         print(f'Diff url {diff_url}')
-        print(f'Before sha {self.before}')
         
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import operator
 
 #TODO First todo
 #TODO Second todo
+#TODO Third todo
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0

--- a/main.py
+++ b/main.py
@@ -87,6 +87,7 @@ class GitHubClient(object):
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'
         }
+        # TODO remove debug log
         print(f'Diff url {diff_url}')
         
         diff_request = requests.get(url=diff_url, headers=diff_headers)

--- a/main.py
+++ b/main.py
@@ -233,7 +233,7 @@ class GitHubClient(object):
             else:
                 print('An error occurred, skipping')
                 continue
-#TODO a third comment
+
             # Use the project ID and column name to get the column ID.
             columns_url = f'{self.base_url}projects/{project_id}/columns'
             columns_request = requests.get(url=columns_url, headers=projects_headers)

--- a/main.py
+++ b/main.py
@@ -226,7 +226,7 @@ class GitHubClient(object):
                 projects_url = f'{self.base_url}orgs/{entity_name}/projects'
             else:
                 return
-
+# TODO 3
             # We need to use the project name to get its ID.
             projects_request = requests.get(url=projects_url, headers=projects_headers)
             if projects_request.status_code == 200:

--- a/main.py
+++ b/main.py
@@ -649,3 +649,4 @@ if __name__ == "__main__":
                 print('Issue could not be closed')
         # Stagger the requests to be on the safe side.
         sleep(1)
+# TODO a comment number six

--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ class GitHubClient(object):
                 + '```' + issue.markdown_language + '\n'
                 + issue.hunk + '\n'
                 + '```')
-
+# TODO - a second comment
         # Check if the current issue already exists - if so, skip it.
         # The below is a simple and imperfect check.
         issue_id = hashlib.sha1(body.encode('utf-8')).hexdigest()

--- a/main.py
+++ b/main.py
@@ -47,7 +47,6 @@ class GitHubClient(object):
     repos_url = f'{base_url}repos/'
 
     def __init__(self):
-        print(f'Init....')
         self.repo = os.getenv('INPUT_REPO')
         self.before = os.getenv('INPUT_BEFORE')
         self.sha = os.getenv('INPUT_SHA')
@@ -83,7 +82,6 @@ class GitHubClient(object):
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'
         }
-        
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text
@@ -103,7 +101,7 @@ class GitHubClient(object):
             links = list_issues_request.links
             if 'next' in links:
                 self._get_existing_issues(page + 1)
-   
+
     def create_issue(self, issue):
         """Create a dict containing the issue details and send it to GitHub."""
         title = issue.title

--- a/main.py
+++ b/main.py
@@ -78,14 +78,9 @@ class GitHubClient(object):
             diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
         else: 
             # There are several commits: compare with the oldest one
-            print("Case 3")
             oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]['id']
-            print(f'oldest sha {oldest}')
             diff_url = f'{self.repos_url}{self.repo}/compare/{oldest}...{self.sha}'    
         
-        oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]['id']
-        print(f'oldest sha {oldest}')
-
         diff_headers = {
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'

--- a/main.py
+++ b/main.py
@@ -62,7 +62,11 @@ class GitHubClient(object):
 
     def get_last_diff(self):
         """Get the last commit diff."""
-        diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
+        if not self.before or self.before.startswith('000000'):
+            # Last commit SHA is empty which means this is the first commit of the branch
+            diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
+        else:    
+            diff_url = f'{self.repos_url}{self.repo}/compare/{self.before}...{self.sha}'
         
         diff_headers = {
             'Accept': 'application/vnd.github.v3.diff',

--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ class GitHubClient(object):
                 self.add_issue_to_projects(issue_id, issue.org_projects, 'org')
 
         return new_issue_request.status_code
-# TODO 2
+        
     def close_issue(self, issue):
         """Check to see if this issue can be found on GitHub and if so close it."""
         matched = 0

--- a/main.py
+++ b/main.py
@@ -61,12 +61,7 @@ class GitHubClient(object):
 
     def get_last_diff(self):
         """Get the last commit diff."""
-        if not self.before or self.before.startswith('000000'):
-            # Last commit SHA is empty which means this is the first commit of the branch
-            diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
-        else:    
-            diff_url = f'{self.repos_url}{self.repo}/compare/{self.before}...{self.sha}'
-        
+        diff_url = f'{self.repos_url}{self.repo}/compare/{self.before}...{self.sha}'
         diff_headers = {
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'

--- a/main.py
+++ b/main.py
@@ -611,7 +611,6 @@ class TodoParser(object):
             projects = list(filter(None, projects.split(',')))
         return projects
 
-# TODO a comment number five
 if __name__ == "__main__":
     # Create a basic client for communicating with GitHub, automatically initialised with environment variables.
     client = GitHubClient()

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ class Issue(object):
         self.start_line = start_line
         self.markdown_language = markdown_language
         self.status = status
-#TODO a first comment
+
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []
@@ -187,7 +187,7 @@ class GitHubClient(object):
                                                  data=json.dumps(body))
             return update_issue_request.status_code
         return None
-#TODO a second comment
+
     def add_issue_to_projects(self, issue_id, projects, projects_type):
         """Attempt to add this issue to the specified user or organisation projects."""
         projects_secret = os.getenv('INPUT_PROJECTS_SECRET', None)

--- a/main.py
+++ b/main.py
@@ -163,7 +163,7 @@ class GitHubClient(object):
                 self.add_issue_to_projects(issue_id, issue.org_projects, 'org')
 
         return new_issue_request.status_code
-
+# TODO - a third comment
     def close_issue(self, issue):
         """Check to see if this issue can be found on GitHub and if so close it."""
         matched = 0

--- a/main.py
+++ b/main.py
@@ -79,11 +79,11 @@ class GitHubClient(object):
         else: 
             # There are several commits: compare with the oldest one
             print("Case 3")
-            oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]
+            oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]['id']
             print(f'oldest sha {oldest}')
             diff_url = f'{self.repos_url}{self.repo}/compare/{oldest}...{self.sha}'    
         
-        oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]
+        oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]['id']
         print(f'oldest sha {oldest}')
 
         diff_headers = {

--- a/main.py
+++ b/main.py
@@ -94,7 +94,6 @@ class GitHubClient(object):
             return diff_request.text
         raise Exception('Could not retrieve diff. Operation will abort.')
 
-# TODO 1
     def _get_existing_issues(self, page=1):
         """Populate the existing issues list."""
         params = {

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ class GitHubClient(object):
             links = list_issues_request.links
             if 'next' in links:
                 self._get_existing_issues(page + 1)
-
+   # TODO remove debug log 2
     def create_issue(self, issue):
         """Create a dict containing the issue details and send it to GitHub."""
         title = issue.title

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ class GitHubClient(object):
         self.repo = os.getenv('INPUT_REPO')
         self.before = os.getenv('INPUT_BEFORE')
         self.sha = os.getenv('INPUT_SHA')
-        self.commits = os.getenv('INPUT_COMMITS')
+        self.commits = json.loads(os.getenv('INPUT_COMMITS'))
         self.token = os.getenv('INPUT_TOKEN')
         self.issues_url = f'{self.repos_url}{self.repo}/issues'
         self.issue_headers = {

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ class GitHubClient(object):
         print(f'Diff url {diff_url}')
         print(f'Before sha {self.before}')
         print(f'Commits unsorted {self.commits}')
-        print(f'Commits sorted {self.commits.sort(key=self.get_timestamp)}')
+        print(f'Commits sorted {sorted(self.commits, key=self.get_timestamp)}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ class GitHubClient(object):
             links = list_issues_request.links
             if 'next' in links:
                 self._get_existing_issues(page + 1)
-   # TODO remove debug log 2
+   
     def create_issue(self, issue):
         """Create a dict containing the issue details and send it to GitHub."""
         title = issue.title

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ class LineStatus(Enum):
     DELETED = 1
     UNCHANGED = 2
 
-
+# Another comment
 class Issue(object):
     """Basic Issue model for collecting the necessary info to send to GitHub."""
 

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ class Issue(object):
         self.start_line = start_line
         self.markdown_language = markdown_language
         self.status = status
-
+#TODO a first comment
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []

--- a/main.py
+++ b/main.py
@@ -70,16 +70,12 @@ class GitHubClient(object):
         """Get the last diff."""
         if self.before != '0000000000000000000000000000000000000000':
             # There is a valid before SHA to compare with
-            print("Case 1")
             diff_url = f'{self.repos_url}{self.repo}/compare/{self.before}...{self.sha}'
         elif len(self.commits) == 1:
             # There is only one commit
-            print("Case 2")
             diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
         else: 
             # There are several commits: compare with the oldest one
-            print("Case 3")
-            print(f'Case 3 commits {self.commits}')
             oldest = sorted(self.commits, key=self.get_timestamp)[0]['id']
             diff_url = f'{self.repos_url}{self.repo}/compare/{oldest}...{self.sha}'    
         
@@ -87,8 +83,6 @@ class GitHubClient(object):
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'
         }
-        # TODO remove debug log
-        print(f'Diff url {diff_url}')
         
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:

--- a/main.py
+++ b/main.py
@@ -79,11 +79,11 @@ class GitHubClient(object):
         else: 
             # There are several commits: compare with the oldest one
             print("Case 3")
-            oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0].id
+            oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]
             print(f'oldest sha {oldest}')
             diff_url = f'{self.repos_url}{self.repo}/compare/{oldest}...{self.sha}'    
         
-        oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0].id
+        oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0]
         print(f'oldest sha {oldest}')
 
         diff_headers = {

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from enum import Enum
 import itertools
 import operator
 
-
+# TODO comment
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ class LineStatus(Enum):
     ADDED = 0
     DELETED = 1
     UNCHANGED = 2
-
+# TODO - a first comment
 class Issue(object):
     """Basic Issue model for collecting the necessary info to send to GitHub."""
 

--- a/main.py
+++ b/main.py
@@ -609,7 +609,7 @@ class TodoParser(object):
             projects = list(filter(None, projects.split(',')))
         return projects
 
-
+# TODO a comment number five
 if __name__ == "__main__":
     # Create a basic client for communicating with GitHub, automatically initialised with environment variables.
     client = GitHubClient()

--- a/main.py
+++ b/main.py
@@ -169,7 +169,7 @@ class GitHubClient(object):
                 self.add_issue_to_projects(issue_id, issue.org_projects, 'org')
 
         return new_issue_request.status_code
-
+# TODO 2
     def close_issue(self, issue):
         """Check to see if this issue can be found on GitHub and if so close it."""
         matched = 0

--- a/main.py
+++ b/main.py
@@ -231,7 +231,7 @@ class GitHubClient(object):
             else:
                 print('An error occurred, skipping')
                 continue
-
+#TODO a third comment
             # Use the project ID and column name to get the column ID.
             columns_url = f'{self.base_url}projects/{project_id}/columns'
             columns_request = requests.get(url=columns_url, headers=projects_headers)

--- a/main.py
+++ b/main.py
@@ -187,7 +187,7 @@ class GitHubClient(object):
                                                  data=json.dumps(body))
             return update_issue_request.status_code
         return None
-
+#TODO third todo
     def add_issue_to_projects(self, issue_id, projects, projects_type):
         """Attempt to add this issue to the specified user or organisation projects."""
         projects_secret = os.getenv('INPUT_PROJECTS_SECRET', None)

--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ class GitHubClient(object):
         if diff_request.status_code == 200:
             return diff_request.text
         raise Exception('Could not retrieve diff. Operation will abort.')
-
+#TODO second todo
     def _get_existing_issues(self, page=1):
         """Populate the existing issues list."""
         params = {

--- a/main.py
+++ b/main.py
@@ -69,6 +69,7 @@ class GitHubClient(object):
             'Authorization': f'token {self.token}'
         }
         logging.debug('URL %', diff_url)
+        print(f'Diff url {diff_url}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text

--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ from enum import Enum
 import itertools
 import operator
 
-#TODO first todo
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0
@@ -78,7 +77,6 @@ class GitHubClient(object):
         if diff_request.status_code == 200:
             return diff_request.text
         raise Exception('Could not retrieve diff. Operation will abort.')
-#TODO second todo
     def _get_existing_issues(self, page=1):
         """Populate the existing issues list."""
         params = {
@@ -191,7 +189,7 @@ class GitHubClient(object):
                                                  data=json.dumps(body))
             return update_issue_request.status_code
         return None
-#TODO third todo
+
     def add_issue_to_projects(self, issue_id, projects, projects_type):
         """Attempt to add this issue to the specified user or organisation projects."""
         projects_secret = os.getenv('INPUT_PROJECTS_SECRET', None)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from enum import Enum
 import itertools
 import operator
 
+#TODO first todo
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0

--- a/main.py
+++ b/main.py
@@ -161,6 +161,7 @@ class GitHubClient(object):
 
         return new_issue_request.status_code
 
+#TODO Third TODO
     def close_issue(self, issue):
         """Check to see if this issue can be found on GitHub and if so close it."""
         matched = 0

--- a/main.py
+++ b/main.py
@@ -13,9 +13,6 @@ from enum import Enum
 import itertools
 import operator
 
-#TODO First todo
-#TODO Second todo
-#TODO Third todo
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ class GitHubClient(object):
         print(f'Diff url {diff_url}')
         print(f'Before sha {self.before}')
         print(f'Commits unsorted {self.commits}')
-        print(f'Commits sorted {sorted(self.commits, key=self.get_timestamp)}')
+        print(f'Commits sorted {sorted(self.commits, key=self.get_timestamp, reverse=True)}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ class GitHubClient(object):
     repos_url = f'{base_url}repos/'
 
     def __init__(self):
+        print(f'Init....')
         self.repo = os.getenv('INPUT_REPO')
         self.sha = os.getenv('INPUT_SHA')
         self.token = os.getenv('INPUT_TOKEN')

--- a/main.py
+++ b/main.py
@@ -63,6 +63,9 @@ class GitHubClient(object):
         # Retrieve the existing repo issues now so we can easily check them later.
         self._get_existing_issues()
 
+    def get_timestamp(commit):
+        return commit.get('timestamp')
+
     def get_last_diff(self):
         """Get the last commit diff."""
         diff_url = f'{self.repos_url}{self.repo}/compare/{self.before}...{self.sha}'

--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ from enum import Enum
 import itertools
 import operator
 
-#TODO First TODO
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
     ADDED = 0
@@ -38,7 +37,6 @@ class Issue(object):
         self.markdown_language = markdown_language
         self.status = status
 
-#TODO Second TODO
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []
@@ -163,7 +161,6 @@ class GitHubClient(object):
 
         return new_issue_request.status_code
 
-#TODO Third TODO
     def close_issue(self, issue):
         """Check to see if this issue can be found on GitHub and if so close it."""
         matched = 0

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ class Issue(object):
         self.markdown_language = markdown_language
         self.status = status
 
-
+#TODO Second todo
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []

--- a/main.py
+++ b/main.py
@@ -79,9 +79,13 @@ class GitHubClient(object):
         else: 
             # There are several commits: compare with the oldest one
             print("Case 3")
-            oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)
-            diff_url = f'{self.repos_url}{self.repo}/compare/{oldest.id}...{self.sha}'    
+            oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0].id
+            print(f'oldest sha {oldest}')
+            diff_url = f'{self.repos_url}{self.repo}/compare/{oldest}...{self.sha}'    
         
+        oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)[0].id
+        print(f'oldest sha {oldest}')
+
         diff_headers = {
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'

--- a/main.py
+++ b/main.py
@@ -185,7 +185,7 @@ class GitHubClient(object):
                                                  data=json.dumps(body))
             return update_issue_request.status_code
         return None
-
+#TODO a second comment
     def add_issue_to_projects(self, issue_id, projects, projects_type):
         """Attempt to add this issue to the specified user or organisation projects."""
         projects_secret = os.getenv('INPUT_PROJECTS_SECRET', None)

--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ class GitHubClient(object):
                 self.add_issue_to_projects(issue_id, issue.org_projects, 'org')
 
         return new_issue_request.status_code
-        
+
     def close_issue(self, issue):
         """Check to see if this issue can be found on GitHub and if so close it."""
         matched = 0
@@ -237,7 +237,7 @@ class GitHubClient(object):
                 projects_url = f'{self.base_url}orgs/{entity_name}/projects'
             else:
                 return
-# TODO 3
+
             # We need to use the project name to get its ID.
             projects_request = requests.get(url=projects_url, headers=projects_headers)
             if projects_request.status_code == 200:

--- a/main.py
+++ b/main.py
@@ -650,4 +650,3 @@ if __name__ == "__main__":
                 print('Issue could not be closed')
         # Stagger the requests to be on the safe side.
         sleep(1)
-# TODO a comment number six

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ class GitHubClient(object):
     def __init__(self):
         print(f'Init....')
         self.repo = os.getenv('INPUT_REPO')
+        self.before = os.getenv('INPUT_BEFORE')
         self.sha = os.getenv('INPUT_SHA')
         self.token = os.getenv('INPUT_TOKEN')
         self.issues_url = f'{self.repos_url}{self.repo}/issues'
@@ -63,11 +64,13 @@ class GitHubClient(object):
     def get_last_diff(self):
         """Get the last commit diff."""
         diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
+        
         diff_headers = {
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'
         }
         print(f'Diff url {diff_url}')
+        print(f'Before sha {self.before}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ class GitHubClient(object):
             'Accept': 'application/vnd.github.v3.diff',
             'Authorization': f'token {self.token}'
         }
+        logging.debug('URL %', diff_url)
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text
@@ -628,4 +629,3 @@ if __name__ == "__main__":
                 print('Issue could not be closed')
         # Stagger the requests to be on the safe side.
         sleep(1)
-        

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ class GitHubClient(object):
         print(f'Diff url {diff_url}')
         print(f'Before sha {self.before}')
         print(f'Commits unsorted {self.commits}')
-        print(f'Commits sorted {self.commits.sort(key=self._get_timestamp)}')
+        print(f'Commits sorted {self.commits.sort(key=self.get_timestamp)}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ class LineStatus(Enum):
     ADDED = 0
     DELETED = 1
     UNCHANGED = 2
-# TODO - a first comment
+
 class Issue(object):
     """Basic Issue model for collecting the necessary info to send to GitHub."""
 
@@ -77,6 +77,7 @@ class GitHubClient(object):
         if diff_request.status_code == 200:
             return diff_request.text
         raise Exception('Could not retrieve diff. Operation will abort.')
+
     def _get_existing_issues(self, page=1):
         """Populate the existing issues list."""
         params = {
@@ -105,7 +106,7 @@ class GitHubClient(object):
                 + '```' + issue.markdown_language + '\n'
                 + issue.hunk + '\n'
                 + '```')
-# TODO - a second comment
+
         # Check if the current issue already exists - if so, skip it.
         # The below is a simple and imperfect check.
         issue_id = hashlib.sha1(body.encode('utf-8')).hexdigest()
@@ -163,7 +164,7 @@ class GitHubClient(object):
                 self.add_issue_to_projects(issue_id, issue.org_projects, 'org')
 
         return new_issue_request.status_code
-# TODO - a third comment
+
     def close_issue(self, issue):
         """Check to see if this issue can be found on GitHub and if so close it."""
         matched = 0

--- a/main.py
+++ b/main.py
@@ -70,12 +70,15 @@ class GitHubClient(object):
         """Get the last diff."""
         if self.before != '0000000000000000000000000000000000000000':
             # There is a valid before SHA to compare with
+            print("Case 1")
             diff_url = f'{self.repos_url}{self.repo}/compare/{self.before}...{self.sha}'
         elif len(self.commits) == 1:
             # There is only one commit
+            print("Case 2")
             diff_url = f'{self.repos_url}{self.repo}/commits/{self.sha}'
         else: 
             # There are several commits: compare with the oldest one
+            print("Case 3")
             oldest = sorted(self.commits, key=self.get_timestamp, reverse=True)
             diff_url = f'{self.repos_url}{self.repo}/compare/{oldest.id}...{self.sha}'    
         

--- a/main.py
+++ b/main.py
@@ -282,7 +282,7 @@ class GitHubClient(object):
             else:
                 print('Issue card could not be added to project')
 
-
+# TODO 4
 class TodoParser(object):
     """Parser for extracting information from a given diff file."""
     FILE_HUNK_PATTERN = r'(?<=diff)(.*?)(?=diff\s--git\s)'

--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ class GitHubClient(object):
         }
         print(f'Diff url {diff_url}')
         print(f'Before sha {self.before}')
-        print(f'Commits {self.commits}')
+        print(f'Commits unsorted {self.commits}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text

--- a/main.py
+++ b/main.py
@@ -76,6 +76,7 @@ class GitHubClient(object):
         print(f'Diff url {diff_url}')
         print(f'Before sha {self.before}')
         print(f'Commits unsorted {self.commits}')
+        print(f'Commits sorted {self.commits.sort(key=self._get_timestamp)}')
         diff_request = requests.get(url=diff_url, headers=diff_headers)
         if diff_request.status_code == 200:
             return diff_request.text


### PR DESCRIPTION
This PR adds support for newly created branches with multiple comments by leveraging on `github.event.commits` to find the oldest one to compare with, since `github.event.before` is empty in these cases